### PR TITLE
modify navbar and pageTitle font

### DIFF
--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -23,7 +23,7 @@ body {
 
 .nav {
   background-color: rgb(31 41 55);
-  font-family: 'system-ui';
+  font-family: 'Times New Roman';
   padding-bottom:       0.50rem;
   padding-inline-start: 80px;
   padding-top:          0.50rem;
@@ -39,7 +39,7 @@ body {
 /* #HEADER */
 
 .page-title {
-  font-family: 'system-ui';
+  font-family: 'Times New Roman';
   font-size:  3rem;
   padding:    1rem;
 }


### PR DESCRIPTION
Since both navbar and pageTitle font set the font as System UI, this means that the font is set as the default font, and the default Western font of Windows is Segoe UI. I've changed the western font to Times New Roman so that it shows the change, and you can adjust it if you want a different font.